### PR TITLE
Fixed 404 for contributing link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@ path if needed.</p>
 <p>Anyone and everyone is welcome to contribute. Please take a moment to
 review the <a href="https://github.com/bower/bower/blob/master/CONTRIBUTING.md">guidelines for contributing</a>.</p>
 
-<ul><li><a href="https://github.com/bower/bower/blob/master/CONTRIBUTING.md#bugs">Bug reports</a></li><li><a href="CONTRIBUTING.md#features">Feature requests</a></li><li><a href="CONTRIBUTING.md#pull-requests">Pull requests</a></li></ul>
+<ul><li><a href="https://github.com/bower/bower/blob/master/CONTRIBUTING.md#bugs">Bug reports</a></li><li><a href="https://github.com/bower/bower/blob/master/CONTRIBUTING.md#features">Feature requests</a></li><li><a href="https://github.com/bower/bower/blob/master/CONTRIBUTING.md#pull-requests">Pull requests</a></li></ul>
 
 <h2>Authors</h2>
 


### PR DESCRIPTION
Just points to the md file at github.com/bower/bower/
