### PR TITLE
Add additional register notes regarding SSH URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ and <a href="http://requirejs.org/">RequireJS</a> -- that will help you do this.
 <p>To register a new package:</p>
 
 <ul><li>There <strong>must</strong> be a valid manifest JSON in the current working directory.</li><li>Your package should use <a href="http://semver.org/">semver</a> Git tags.</li><li>Your package <strong>must</strong> be available at a Git endpoint (e.g., GitHub); remember
-to push your Git tags!</li></ul>
+to push your Git tags! <br>A sample Git endpoint could be <code>git://github.com/someone/some-package.git</code>. <br><em>Note that SSH URLs cannot be used and will cause an error.</em></li></ul>
 
 <p>Then use the following command:</p>
 


### PR DESCRIPTION
I added some additional notes to the website at the register package section regarding SSH URLs as I myself and many others ran into trouble registering a package with an invalid URL so it needs to be updated or removed to work with bower.
As the register process doesn't throw an error in some cases and to prevent trouble I added this. Feel free to add it.
