### PR TITLE
Added link to version ranges syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ extracted.</li></ul>
 
 <p>‡ These types of <code>&lt;package&gt;</code> might have versions available. You can specify a
 <a href="http://semver.org/">semver</a> compatible version to fetch a specific release, and lock the
-package to that version. You can also use ranges to specify a range of versions.</p>
+package to that version. You can also use <a href="https://www.npmjs.org/doc/misc/semver.html#Ranges">ranges</a> to specify a range of versions.</p>
 
 <p>If you are using a package that is a git endpoint, you may use any tag, commit SHA,
 or branch name as a version. For example: <code>&lt;package&gt;#&lt;sha&gt;</code>. Using branches is not


### PR DESCRIPTION
This has been very unclear, see https://github.com/bower/bower/issues/505#issuecomment-37511088 for an example.
