### PR TITLE
remove 'by twitter'

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
           <h1>Bower</h1>
         </div>
         <h3 class="tagline">A package manager for the web</h3>
-        <h3 class="by-twitter">By Twitter</h3>
         <a href="https://github.com/bower/bower" target="_blank" class="button github-button">View on GitHub</a>
         <a href="http://bower.io/search/" class="button">Search Packages</a>
       </div>


### PR DESCRIPTION
removing the 'by twitter' line now that the bower core team is all now non-twitter employees. for more context: https://github.com/bower/bower.github.io/commit/e7832caaac5231f66dc4a2a72a50a2e6e18d41db#commitcomment-6204149
