### PR TITLE
Update "grunt-bower-install" to "grunt-wiredep"

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,7 +10,7 @@ layout: default
 [**grunt-bower-concat**](https://github.com/sapegin/grunt-bower-concat) <br>
 Grunt task for automatically concat all installed Bower components.
 
-[**grunt-bower-install**](https://github.com/stephenplusplus/grunt-bower-install) <br>
+[**grunt-wiredep**](https://github.com/stephenplusplus/grunt-wiredep) <br>
 Inject your Bower components right into your HTML using Grunt.
 
 [**grunt-bower-requirejs**](https://github.com/yeoman/grunt-bower-requirejs) <br>


### PR DESCRIPTION
"grunt-bower-install" is now named "grunt-wiredep".
https://github.com/stephenplusplus/grunt-wiredep/issues/78

I updated the name and URL in the Tools section.
Thanks.
