### PR TITLE
Add a coma to .bowerrc to be a valid json file

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,7 @@ layout: default
 <p class="lead">Bower can be configured using JSON in a .bowerrc file. For example:</p>
 
     {
-      "directory": "app/components/"
+      "directory": "app/components/",
       "analytics": false
     }
 


### PR DESCRIPTION
The missing coma on the second line make the json invalid.

```
jeremy@dev-php:~/dev$ bower install

/usr/local/node/lib/node_modules/bower/node_modules/bower-config/lib/util/rc.js:55
        throw error;
              ^
Error: Unable to parse /space/home/jeremy/dev/.bowerrc: Unexpected string
```
