### PR TITLE
Change monospace font for GNU/Linux users

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -502,7 +502,7 @@ td {
 /* ---- code ---- */
 
 pre, code {
-  font-family: Consolas, Menlo, Courier, monospace;
+  font-family: Consolas, Menlo, Liberation Mono, monospace;
 }
 
 code {


### PR DESCRIPTION
Courier is not a very nice coding font, but it shows up as default for most GNU/Linux users. Liberation is pretty popular and `monospace` is a fine-enough backup that will probably show Courier anyway if unavailable. Web safe monospace fonts on Linux are confusing lol.