### PR TITLE
List examples of Git endpoints that do not end with .git

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -129,6 +129,13 @@ Where:
     </td>
   </tr>
   <tr>
+    <td>Git endpoint without .git</td>
+    <td>
+      <code>git+https://github.com/user/package</code><br>
+      <code>git+ssh://git@github.com/user/package</code>
+    </td>
+  </tr>
+  <tr>
     <td>Local folder</td>
     <td><code>my/local/folder/</code></td>
   </tr>


### PR DESCRIPTION
We've bumped into this one as well: https://github.com/bower/bower/issues/546

Some hosting providers such as [Deveo](https://deveo.com/) do not have the .git at the end of the endpoint, hence mention it in API documentation.

