### PR TITLE
Hint users to copy git endpoint from GitHub

### DIFF
--- a/docs/creating-packages.md
+++ b/docs/creating-packages.md
@@ -83,8 +83,10 @@ Then use [`bower register`](/docs/api#register):
 {% highlight bash %}
 $ bower register <my-package-name> <git-endpoint>
 # for example
-$ bower register example git://github.com/user/example.git
+$ bower register example https://github.com/user/example.git
 {% endhighlight %}
+
+For packages hosted on GitHub, you can use the HTTPS clone url from the repository's main page as your git endpoint.
 
 Now anyone can run `bower install <my-package-name>`, and get your library installed. The Bower registry does not have authentication or user management at this point in time. It's on a first come, first served basis.
 


### PR DESCRIPTION
Based on comments on the [unregister request issue](https://github.com/bower/bower/issues/120), a lot of folks are making mistakes while manually typing a github endpoint for the register command. Adding a tip to copy the url from the GitHub clone widget could alleviate some of the manual request load.