### PR TITLE
Fix path of apple-touch-icon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
 
   <title>{% unless page.is_home %}{{ page.title }} &middot; {% endunless %}Bower</title>
 
-  <link rel="apple-touch-icon" href="apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
   <link rel="stylesheet" type="text/css" href="/css/styles.css">
 


### PR DESCRIPTION
The reference in subdirectory page is missing.