### PR TITLE
Typo in env variable name bowser_storage_cache

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -39,7 +39,7 @@ Example of CLI arguments:
 Example of valid environment variables:
 
 * `bower_endpoint_parser` is evaluated as `endpoint-parser`
-* `bower_storage__cache` is evaluated as `storage.cache`
+* `bower_storage_cache` is evaluated as `storage.cache`
 
 ## .bowerrc specification
 


### PR DESCRIPTION
I copy pasted this to somewhere and noticed it had two underscores.