### PR TITLE
Adds responsive viewport, reduces fontsize on pre tags, and removes a horizontal scrollbar on API section

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="google-site-verification" content="1XwfuTPiyoCivlUjHLisCr8ukNu3tiv0Ax_wDx3-BhY" />
-
+  <meta name="viewport" content="initial-scale=1">
+  
   <title>{% unless page.is_home %}{{ page.title }} &middot; {% endunless %}Bower</title>
 
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">

--- a/css/base.css
+++ b/css/base.css
@@ -139,3 +139,15 @@ code .nv {
        -o-user-select: none;
           user-select: none;
 }
+
+
+/* ---- Responsive styles ---- */
+
+pre {
+  font-size: 0.8em;
+  padding: 0.8em;
+  border-radius: 3px;
+}
+td {
+  font-size: 0.65em;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -565,6 +565,18 @@ code .nv {
           user-select: none;
 }
 
+
+/* ---- Responsive styles ---- */
+
+pre {
+  font-size: 0.8em;
+  padding: 0.8em;
+  border-radius: 3px;
+}
+td {
+  font-size: 0.65em;
+}
+
 #masthead {
   background: #FFCC2F;
   color: #543729;


### PR DESCRIPTION
@desandro Sorry, didn't realize that the responsive meta tag didn't exist. Won't work on phones until this is in. Added that, plus:

- Fixed API from having a horizontal scrollbar
- Decreased font size on pre tags, so code is a little more readable:

![pre](https://cloud.githubusercontent.com/assets/296130/7839987/f327a5fe-045a-11e5-87cd-85339d86d80d.jpg)


