### PR TITLE
Add direct method to using packages in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -53,7 +53,11 @@ Save your packages to [`bower.json` with `bower init`](/docs/creating-packages/#
 
 ### Use packages
 
-How you use packages is up to you. Use Bower together with [Grunt, RequireJS, Yeoman, and lots of other tools](/docs/tools/) or build your own workflow with [the API](/docs/api/).
+How you use packages is up to you. We recommend you use Bower together with [Grunt, RequireJS, Yeoman, and lots of other tools](/docs/tools/) or build your own workflow with [the API](/docs/api/). You can also use the installed packages directly, like this, in the case of `jquery`:
+
+{% highlight html %}
+<script src="bower_components/jquery/dist/jquery.min.js"></script>
+{% endhighlight %}
 
 ## Twitter updates from [@bower](https://twitter.com/bower)
 


### PR DESCRIPTION
As a newcomer to the Javascript ecosystem, tools like Grunt, RequireJS,
Yeoman and so on are entirely new to me, and so it's unhelpful to be
expected to know what these tools do before understanding how to use
the packages installed by Bower.

This is the simplest way to use Bower (although, I assume, not the
best), I think it makes it clear that all Bower does is install packages
in `bower_components` and it is up to the user to use them or build them
as needed.