### PR TITLE
Remove information about core team

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -7,16 +7,6 @@ layout: default
 
 Bower was created at Twitter by [@fat](https://github.com/fat) and [@maccman](https://github.com/maccman), originally released as part of [Twitter's open source effort](https://engineering.twitter.com/opensource) in 2012. Since its release, [numerous individuals have made contributions](https://github.com/bower/bower/graphs/contributors). Bower is a team effort.
 
-## Core team
-
-* [@satazor](https://github.com/satazor)
-* [@wibblymat](https://github.com/wibblymat)
-* [@paulirish](https://github.com/paulirish)
-* [@benschwarz](https://github.com/benschwarz)
-* [@sindresorhus](https://github.com/sindresorhus)
-* [@svnlto](https://github.com/svnlto)
-* [@sheerun](https://github.com/sheerun)
-
 ## Contributing
 
 Help make Bower better. We welcome contributions of all kinds. Please take a moment to review the [guidelines for contributing](https://github.com/bower/bower/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
I feel we don't need that section. Especially most of core team is currently inactive. Hm?