### PR TITLE
state default for strict-ssl setting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -226,7 +226,7 @@ The timeout to be used when making requests in milliseconds, defaults to
 
 `Boolean`
 
-Whether or not to do SSL key validation when making requests via https.
+Whether or not to do SSL key validation when making requests via https, defaults to true.
 
 {% highlight json %}
 "strict-ssl": false


### PR DESCRIPTION
Current example for strict-ssl section leads one to suspect that Bower doesn't perform TLS validation by default.  I believe this is incorrect, or at least Bower chocked when I added a dependency with a URL that used a self-signed certificate.