### PR TITLE
Adds a loud banner that calls out for supporting bower

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,6 +40,16 @@
       <h1 class="page-title">{{ page.title }}</h1>
       {% endunless %}
 
+      <div class="callout">
+        <p>
+          Bower needs resources for its maintenance
+        </p>
+        <small>
+          Please fill in the 
+          <a href="http://goo.gl/forms/P1ndzCNoiG">Support Declaration</a> 
+          if you think you can help
+        </small>
+      </div>
 
     </div>
   </header>

--- a/css/masthead.css
+++ b/css/masthead.css
@@ -158,6 +158,27 @@ a:hover img.logo {
   color: #543729;
 }
 
+/* ---- callout ---- */
+
+.callout {
+    background-color: #EF5734;
+    padding: 0.1em;
+    text-align: center;
+    font-size: 4vmin;
+    color: white;
+    font-weight: bold;
+    border-radius: 0.35em;
+    border: 0.2em solid #543729;
+}
+
+.callout p {
+    margin: 0;
+}
+
+.callout a {
+    color: #FFCC2F;
+}
+
 /* ---- Responsive styles ---- */
 
 @media screen and (max-width: 667px) {


### PR DESCRIPTION
Adding to the discussion about [making the need for support more clear](https://github.com/bower/bower/pull/1748#issuecomment-156746373), I thought this might be helpful.

Personally I don't think that adding a rather obtrusive banner to the banner website is a "Bad Idea"<sup>TM</sup>. It makes it _very clear_ how badly support is needed and how much the community at large is falling Bower in offering this.

Feel free to close/ignore this PR if you deem it to be _too_ gaudy. Just consider it the 2 cents of someone who feels talk is cheap (only slightly more so than pull-requests).