### PR TITLE
add a suggestion for main page copy

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -418,7 +418,7 @@ Allows running commands as root. Bower is a user command, there is no need to ex
 
 ## Consuming a package
 
-Bower makes source mapping available. This can be used by [build tools](/docs/tools) to
+You can use [build tools](/docs/tools) to
 easily consume Bower packages.
 
 If you use [`bower list --paths`](#list) or `bower list --paths --json`, you will get a simple name-to-path mapping:

--- a/docs/api.md
+++ b/docs/api.md
@@ -225,7 +225,7 @@ The link functionality allows developers to easily test their packages. Linking 
 
 Using 'bower link' in a project folder will create a global link. Then, in some other package, `bower link <name>` will create a link in the components folder pointing to the previously created link.
 
-This allows to easily test a package because changes will be reflected immediately. When the link is no longer necessary, simply remove it with `bower uninstall <name>`.
+This allows you to easily test a package because changes will be reflected immediately. When the link is no longer necessary, simply remove it with `bower uninstall <name>`.
 
 ### list
 
@@ -418,7 +418,7 @@ Allows running commands as root. Bower is a user command, there is no need to ex
 
 ## Consuming a package
 
-Bower makes available source mapping. This can be used by [build tools](/docs/tools) to
+Bower makes source mapping available. This can be used by [build tools](/docs/tools) to
 easily consume Bower packages.
 
 If you use [`bower list --paths`](#list) or `bower list --paths --json`, you will get a simple name-to-path mapping:
@@ -470,7 +470,7 @@ Commands emit four types of events: `log`, `prompt`, `end`, `error`.
 For a better idea of how this works, you may want to check out [our bin
 file](https://github.com/bower/bower/blob/master/bin/bower).
 
-When using bower programmatically, prompting is disabled by default. Though you can enable it when calling commands with `interactive: true` in the config.
+When using Bower programmatically, prompting is disabled by default. You can enable it when calling commands with `interactive: true` in the config.
 This requires you to listen for the `prompt` event and handle the prompting yourself. The easiest way is to use the [inquirer](https://npmjs.org/package/inquirer) npm module like so:
 
 {% highlight js %}
@@ -501,10 +501,10 @@ $ bower install --config.interactive=false
 Bower works by default in interactive mode. There are few ways of disabling it:
 
 - passing `CI=true` in environment
-- passing `--config.interactive=false` to bower command
-- attaching a pipe to bower (e.g. `bower install | cat`)
+- passing `--config.interactive=false` to Bower command
+- attaching a pipe to Bower (e.g. `bower install | cat`)
 - redirecting output to file (e.g. `bower install > logs.txt`)
-- running bower through its [Programmatic API](#programmatic-api)
+- running Bower through its [Programmatic API](#programmatic-api)
 
 When interactive mode is disabled:
 
@@ -517,7 +517,7 @@ When interactive mode is disabled:
 
 ## Using local cache
 
-Bower supports installing packages from its local cache -- without internet connection -- if the packages were installed before.
+Bower supports installing packages from its local cache -- without an internet connection -- if the packages were installed before.
 
 {% highlight sh %}
 $ bower install <package> --offline

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ is_home: true
 
 <p class="lead">Web sites are made of lots of things — frameworks, libraries, assets, and utilities. Bower manages all these things for you.</p>
 
-Keeping track of all these packages and making sure they are up to date (or set to the specific verions you need) is tricky. Bower to the rescue! 
+Keeping track of all these packages and making sure they are up to date (or set to the specific versions you need) is trick. Bower to the rescue!
 
 Bower isn't limited to JavaScript libraries and can manage any front-end components, including CSS (e.g. Bootstrap), HTML or static assets like images. Bower doesn't concatenate or minify code or do anything else. All Bower does is install the right versions of the packages you need and their dependencies. It's completely dedicated to managing your packages.
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ is_home: true
 
 <p class="lead">Web sites are made of lots of things — frameworks, libraries, assets, and utilities. Bower manages all these things for you.</p>
 
-Keeping track of all these packages and making sure they are up to date (or set to the specific versions you need) is trick. Bower to the rescue!
+Keeping track of all these packages and making sure they are up to date (or set to the specific versions you need) is tricky. Bower to the rescue!
 
 Bower isn't limited to JavaScript libraries and can manage any front-end components, including CSS (e.g. Bootstrap), HTML or static assets like images. Bower doesn't concatenate or minify code or do anything else. All Bower does is install the right versions of the packages you need and their dependencies. It's completely dedicated to managing your packages.
 

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Bower can manage components that contain HTML, CSS, JavaScript, fonts or even im
 
 To [get started](#getting-started), Bower works by fetching and installing [packages](/search) from all over, taking care of hunting, finding, downloading, and saving the stuff you're looking for. Bower keeps track of these packages in a manifest file, [`bower.json`](/docs/creating-packages/#bowerjson). How you use [packages](/search) is up to you. Bower provides hooks to facilitate using packages in your [tools and workflows](/docs/tools).
 
-Bower is optimized for the front-end. If a package (let's use jQuery as an example) has multiple packages depending on it, Bower will download jQuery just once. This is known as a flat dependency graph and it helps reduce page load. (In this case, NPM would download multiple versions of jQuery).
+Bower is optimized for the front-end. If a package (let's use jQuery as an example) has multiple packages depending on it, Bower will download jQuery just once. This is known as a flat dependency graph and it helps reduce page load. (NPM, on the other hand, will download a version of jQuery for every package that depends on it).
 
 ## Install Bower
 

--- a/index.md
+++ b/index.md
@@ -12,11 +12,11 @@ Bower can manage components that contain HTML, CSS, JavaScript, fonts or even im
 
 To [get started](#getting-started), Bower works by fetching and installing [packages](/search) from all over, taking care of hunting, finding, downloading, and saving the stuff you're looking for. Bower keeps track of these packages in a manifest file, [`bower.json`](/docs/creating-packages/#bowerjson). How you use [packages](/search) is up to you. Bower provides hooks to facilitate using packages in your [tools and workflows](/docs/tools).
 
-Bower is optimized for the front-end. If a package (let's use jQuery as an example) has multiple packages depending on it, Bower will download jQuery just once. This is known as a flat dependency graph and it helps reduce page load. (NPM, on the other hand, will download a version of jQuery for every package that depends on it).
+Bower is optimized for the front-end. If multiple packages depend on a package - jQuery for example - Bower will download jQuery just once. This is known as a flat dependency graph and it helps reduce page load.
 
 ## Install Bower
 
-Bower is a command line utility. Install it globally with npm.
+Bower is a command line utility. Install it with npm.
 
 {% highlight bash %}
 $ npm install -g bower

--- a/index.md
+++ b/index.md
@@ -6,13 +6,18 @@ is_home: true
 
 <p class="lead">Web sites are made of lots of things — frameworks, libraries, assets, and utilities. Bower manages all these things for you.</p>
 
+Keeping track of all these packages and making sure they are up to date (or set to the specific verions you need) is tricky. Bower to the rescue! 
+
+Bower isn't limited to JavaScript libraries and can manage any front-end components, including CSS (e.g. Bootstrap), HTML or static assets like images. Bower doesn't concatenate or minify code or do anything else. All Bower does is install the right versions of the packages you need and their dependencies. It's completely dedicated to managing your packages.
+
 To [get started](#getting-started), Bower works by fetching and installing [packages](/search) from all over, taking care of hunting, finding, downloading, and saving the stuff you're looking for. Bower keeps track of these packages in a manifest file, [`bower.json`](/docs/creating-packages/#bowerjson). How you use [packages](/search) is up to you. Bower provides hooks to facilitate using packages in your [tools and workflows](/docs/tools).
 
-Bower is optimized for the front-end. Bower uses a flat dependency tree, requiring only one version for each package, reducing page load to a minimum.
+Bower is optimized for the front-end. It will install packages only once (e.g. JQuery would always be in 
+`bower_components/jquery`, no matter how many packages depend on it). In the case of a conflict, Bower just won't install the package that conflicts with what's already installed. This helps reduce page load to a minimum.
 
 ## Install Bower
 
-Bower is a command line utility. Install it with npm.
+Bower is a command line utility. Install it globally with npm.
 
 {% highlight bash %}
 $ npm install -g bower

--- a/index.md
+++ b/index.md
@@ -8,12 +8,12 @@ is_home: true
 
 Keeping track of all these packages and making sure they are up to date (or set to the specific versions you need) is tricky. Bower to the rescue!
 
-Bower isn't limited to JavaScript libraries and can manage any front-end components, including CSS (e.g. Bootstrap), HTML or static assets like images. Bower doesn't concatenate or minify code or do anything else. All Bower does is install the right versions of the packages you need and their dependencies. It's completely dedicated to managing your packages.
+Bower can manage components that contain HTML, CSS, JavaScript, fonts or even image files. Bower doesn't concatenate or minify code or do anything else - it just installs the right versions of the packages you need and their dependencies.
 
 To [get started](#getting-started), Bower works by fetching and installing [packages](/search) from all over, taking care of hunting, finding, downloading, and saving the stuff you're looking for. Bower keeps track of these packages in a manifest file, [`bower.json`](/docs/creating-packages/#bowerjson). How you use [packages](/search) is up to you. Bower provides hooks to facilitate using packages in your [tools and workflows](/docs/tools).
 
 Bower is optimized for the front-end. It will install packages only once (e.g. JQuery would always be in 
-`bower_components/jquery`, no matter how many packages depend on it). In the case of a conflict, Bower just won't install the package that conflicts with what's already installed. This helps reduce page load to a minimum.
+`bower_components/jquery`, no matter how many packages depend on it). This helps reduce page load to a minimum.
 
 ## Install Bower
 

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Bower can manage components that contain HTML, CSS, JavaScript, fonts or even im
 
 To [get started](#getting-started), Bower works by fetching and installing [packages](/search) from all over, taking care of hunting, finding, downloading, and saving the stuff you're looking for. Bower keeps track of these packages in a manifest file, [`bower.json`](/docs/creating-packages/#bowerjson). How you use [packages](/search) is up to you. Bower provides hooks to facilitate using packages in your [tools and workflows](/docs/tools).
 
-Bower is optimized for the front-end. If a package (lets use jQuery as an example) has multiple packages depending on it, Bower will download jQuery just once. This is known as a flat dependency graph and it helps reduce page load. (In this case, NPM would download multiple versions of jQuery).
+Bower is optimized for the front-end. If a package (let's use jQuery as an example) has multiple packages depending on it, Bower will download jQuery just once. This is known as a flat dependency graph and it helps reduce page load. (In this case, NPM would download multiple versions of jQuery).
 
 ## Install Bower
 

--- a/index.md
+++ b/index.md
@@ -12,8 +12,7 @@ Bower can manage components that contain HTML, CSS, JavaScript, fonts or even im
 
 To [get started](#getting-started), Bower works by fetching and installing [packages](/search) from all over, taking care of hunting, finding, downloading, and saving the stuff you're looking for. Bower keeps track of these packages in a manifest file, [`bower.json`](/docs/creating-packages/#bowerjson). How you use [packages](/search) is up to you. Bower provides hooks to facilitate using packages in your [tools and workflows](/docs/tools).
 
-Bower is optimized for the front-end. It will install packages only once (e.g. JQuery would always be in 
-`bower_components/jquery`, no matter how many packages depend on it). This helps reduce page load to a minimum.
+Bower is optimized for the front-end. If a package (lets use jQuery as an example) has multiple packages depending on it, Bower will download jQuery just once. This is known as a flat dependency graph and it helps reduce page load. (In this case, NPM would download multiple versions of jQuery).
 
 ## Install Bower
 


### PR DESCRIPTION
Adds a suggestion for copy on the main page to explain what bower is to users and how it works in plain language. Maybe this is too beginner-orientated - just a suggestion/draft following the discussion on #105 opened by @kevdez (since closed by @desandro as too broad at the time) 