### PR TITLE
update to jekyll 3.0.0 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ markdown: kramdown
 permalink: /:categories/:year/:title/
 paginate: 5
 paginate_path: /blog/page:num/
+gems: [jekyll-paginate]
 exclude:
   - bower.json
   - package.json


### PR DESCRIPTION
Recently Jekyll is updated to 3.0.0 version. So when you run a `jekyll serve`, it depends on paginate gem now.

Refs: [update to jekyll 3.0.0 ](http://kersulis.github.io/2015/10/31/jekyll-3/), [Github Pages gem support for Jekyll 3.0.0](https://talk.jekyllrb.com/t/github-pages-gem-support-for-jekyll-3-0-0/1437)