### PR TITLE
Added documentation for --force, a starting point for issue #200

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -372,6 +372,10 @@ $ bower version patch -m "Upgrade to %s for reasons"
 
 Makes various commands more forceful
 
+- `bower install --force` re-installs all installed components. It also forces installation even when there are non-bower directories with the same name in the components directory. Adding `--force` also bypasses the cache, and writes to the cache anyway.
+- `bower uninstall <package> --force` continues uninstallation even after a dependency conflict
+- `bower unregister <package> --force` bypasses confirmation
+
 ### json
 
 {% highlight sh %}


### PR DESCRIPTION
Added the following to the docs/api.md:

- `bower install --force` re-installs all installed components. It also forces installation even when there are non-bower directories with the same name in the components directory. Adding `--force` also bypasses the cache, and writes to the cache anyway.
- `bower uninstall <package> --force` continues uninstallation even after a dependency conflict
- `bower unregister <package> --force` bypasses confirmation
