### PR TITLE
Add documentation for bower install

### DIFF
--- a/index.md
+++ b/index.md
@@ -41,6 +41,8 @@ $ bower install <package>
 A package can be a GitHub shorthand, a Git endpoint, a URL, and more. Read more about [`bower install`](/docs/api/#install).
 
 {% highlight bash %}
+# installs the project dependencies listed in bower.json
+$ bower install
 # registered package
 $ bower install jquery
 # GitHub shorthand
@@ -59,7 +61,7 @@ $ bower install http://example.com/script.js
 
 Create a `bower.json` file for your package with [`bower init`](/docs/creating-packages/#bowerjson).
 
-Then save new dependencies to your `bower.json` with `bower install PACKAGE --save` 
+Then save new dependencies to your `bower.json` with `bower install PACKAGE --save`
 
 ### Use packages
 


### PR DESCRIPTION
I added a sentence like suggest #215 (maybe it isn't the right place to put it):
![capture](https://cloud.githubusercontent.com/assets/5300939/12925565/1f677b42-cf5f-11e5-9566-ad9b1d5fa1a4.PNG)
