### PR TITLE
Add missing scripts and ignoredDependencies properties to .bowerrc sample

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -69,6 +69,14 @@ Available configuration variables, in `.bowerrc` format:
   ],
   "shallowCloneHosts": [
     "myGitHost.example.com"
+  ],
+  "scripts": {
+    "preinstall": "",
+    "postinstall": "",
+    "preuninstall": ""
+  },
+  "ignoredDependencies": [
+    "jquery"   
   ]
 }
 {% endhighlight %}


### PR DESCRIPTION
Per the documentation [here](https://github.com/bower/spec/blob/master/config.md#ignoreddependencies), the `.bowerrc` file allows the `scripts` and `ignoredDependencies` properties. This PR updates the `.bowerrc` specification sample to include these 2 properties.