### PR TITLE
tools.md: Add VSTS Bower extension to tools list

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -131,3 +131,6 @@ Bower extension for Brackets. It lets you manage your application's dependencies
 
 [**Django-bower**](https://github.com/nvbn/django-bower) <br>
 Easy way to use bower with your [Django](https://www.djangoproject.com/) project
+
+[**vsts-bower**](https://marketplace.visualstudio.com/items?itemName=touchify.vsts-bower) <br>
+Bower extension for [Visual Studio Team Services](https://www.visualstudio.com/en-us/products/visual-studio-team-services-vs.aspx) Continuous Integration builds - also on [Github](https://github.com/touchifyapp/vsts-bower).


### PR DESCRIPTION
Hi,

Bower Extension is now available in the Visual Studio Team Services Marketplace.
It allows to easily install (or manage) Bower dependencies during your CI builds.

I added the links to extension on the Marketplace and to extension sources.

**Marketplace:** https://marketplace.visualstudio.com/items?itemName=touchify.vsts-bower
**Source:** https://github.com/touchifyapp/vsts-bower

Thanks.