### PR TITLE
added save and save-exact to the sample .bowerrc file in docs/config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -63,6 +63,8 @@ Available configuration variables, in `.bowerrc` format:
   "ca": "/var/certificate.pem",
   "color": true,
   "timeout": 60000,
+  "save": true,
+  "save-exact": true,
   "strict-ssl": true,
   "storage": {
     "packages" : "~/.bower/packages",
@@ -82,7 +84,7 @@ Available configuration variables, in `.bowerrc` format:
     "preuninstall": ""
   },
   "ignoredDependencies": [
-    "jquery"   
+    "jquery"
   ]
 }
 {% endhighlight %}


### PR DESCRIPTION
In a recent version the option to use save and save-exact in .bowerrc was added, but it was not reflected in the documentation.