### PR TITLE
Add jekyll-paginate dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN npm install -g bower && \
     npm install -g grunt-cli && \
     apt-get update && \
     apt-get install -y ruby ruby-dev && \
-    gem install jekyll
+    gem install jekyll && \
+    gem install jekyll-paginate

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm install
 grunt
 # install jekyll (You may need sudo here)
 gem install jekyll
+gem install jekyll-paginate
 # serve site to view locally
 jekyll serve
 ```


### PR DESCRIPTION
Found missing dependency while building/running the Docker image.


### Steps
Followed steps in README:

1. `docker build -t bower-io .`
2. `docker run -t -v $(pwd):/opt/code:rw --rm bower-io npm install`
3. `docker run -t -v $(pwd):/opt/code:rw --rm bower-io grunt`
4. `docker run --rm -ti -p 4000:4000 -v $(pwd):/opt/code:rw bower-io jekyll serve --host 0.0.0.0`

Observed following error:

	Configuration file: /opt/code/_config.yml
	  Dependency Error: Yikes! It looks like you don't have jekyll-paginate or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- jekyll-paginate' If you run into trouble, you can find helpful resources at http://jekyllrb.com/help/! 
	jekyll 3.1.3 | Error:  jekyll-paginate