### PR TITLE
Made search a bit sensitive to the type of key pressed

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36759,7 +36759,12 @@ function renderSearch() {
 
   search = _.debounce(search, 1000);
 
-  queryInput.addEventListener('keydown', function() {
+  queryInput.addEventListener('keydown', function(evt) {
+    if (evt.code && (['ControlLeft', 'ControlRight',
+                      'AltLeft', 'AltRight',
+                      'OSLeft', 'OSRight',
+                      'ShiftLeft', 'ShiftRight', ]).indexOf(evt.code) != -1)
+      return;
     state.results = [];
     state.flash = {
       message: 'Loading search results...'

--- a/js/index.js
+++ b/js/index.js
@@ -180,7 +180,12 @@ function renderSearch() {
 
   search = _.debounce(search, 1000);
 
-  queryInput.addEventListener('keydown', function() {
+  queryInput.addEventListener('keydown', function(evt) {
+    if (evt.code && (['ControlLeft', 'ControlRight',
+                      'AltLeft', 'AltRight',
+                      'OSLeft', 'OSRight',
+                      'ShiftLeft', 'ShiftRight', ]).indexOf(evt.code) != -1)
+      return;
     state.results = [];
     state.flash = {
       message: 'Loading search results...'


### PR DESCRIPTION
Currently, when user is in search page, new query for results is sent whenever a 'keydown' event happens, regardless of the type of button pressed. This means that even buttons like 'ctrl', 'shift' and 'alt' trigger a query when pressed.

I know it's a bit trivial change to the behaviour, but this has been bugging me for few days now :sweat_smile:, Especially when I press Ctrl key just to copy some text, or to switch to another tab/window.