### PR TITLE
Rollback unregister documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -24,6 +24,7 @@ Command line reference
 * [search](#search)
 * [update](#update)
 * [uninstall](#uninstall)
+* [unregister](#unregister)
 * [version](#version)
 
 ### cache
@@ -263,7 +264,7 @@ Look up a package URL by name
 $ bower login
 {% endhighlight %}
 
-Authenticate with GitHub and store credentials.
+Authenticate with GitHub and store credentials. Required to unregister packages.
 
 #### login options
 
@@ -322,6 +323,14 @@ Uninstalls a package locally from your bower_components directory
 * `-S`, `--save`: Remove uninstalled packages from the project's bower.json dependencies
 * `-D`, `--save-dev`: Remove uninstalled packages from the project's bower.json devDependencies
 
+### unregister
+
+{% highlight sh %}
+$ bower unregister <package>
+{% endhighlight %}
+
+Unregisters a package.
+
 ### version
 
 {% highlight sh %}
@@ -365,7 +374,7 @@ Makes various commands more forceful
 
 - `bower install --force` re-installs all installed components. It also forces installation even when there are non-bower directories with the same name in the components directory. Adding `--force` also bypasses the cache, and writes to the cache anyway.
 - `bower uninstall <package> --force` continues uninstallation even after a dependency conflict
-- `bower register <package> --force` bypasses confirmation. Login is still needed.
+- `bower register <package> --force` and `bower unregister <package> --force` bypasses confirmation. Login is still needed.
 
 ### json
 
@@ -516,7 +525,7 @@ Bower works by default in interactive mode. There are few ways of disabling it:
 When interactive mode is disabled:
 
 - `bower init` does not work
-- `bower register` bypass confirmation
+- `bower register` and `bower unregister` bypass confirmation
 - `bower login` fails unless `--token` parameter is provided
 - `bower install` fails on resolution conflicts, instead of asking for choice
 - `bower uninstall` doesn't ask for confirmation if dependency is to be removed

--- a/docs/creating-packages.md
+++ b/docs/creating-packages.md
@@ -64,4 +64,17 @@ Please do not squat on package names. Register your package and claim your name 
 
 For package name transfers, intellectual property and other disputes, please try to resolve with the owner first. If no resolution, please submit a ticket in the [Bower Registry repo](https://github.com/bower/registry) and the Bower Core Team will assist.
 
-You'll likely want to [`bower cache clean`](/docs/api#cache-clean) after your change. At the moment the  `unregister` command is temporarily disabled. You can check out this issue - [#2210](https://github.com/bower/bower/issues/2210), for more information. However, you can [request a package to be unregistered manually](https://github.com/bower/bower/issues/120).
+### Unregister
+
+You can unregister packages with [`bower unregister`](/docs/api/#unregister). You first need to authenticate with GitHub with [`bower login`](/docs/api/#login) to confirm you are a contributor to the package repo.
+
+{% highlight bash %}
+bower login
+# enter username and password
+? Username:
+? Password:
+# unregister packages after successful login
+bower unregister <package>
+{% endhighlight %}
+
+You'll likely want to [`bower cache clean`](/docs/api#cache-clean) after your change. Please remember it is generally considered bad behavior to remove versions of a library that others are depending on. Think twice :) If the above doesn't work for you, you can [request a package be unregistered manually](https://github.com/bower/bower/issues/120).

--- a/docs/creating-packages.md
+++ b/docs/creating-packages.md
@@ -77,4 +77,4 @@ bower login
 bower unregister <package>
 {% endhighlight %}
 
-You'll likely want to [`bower cache clean`](/docs/api#cache-clean) after your change. Please remember it is generally considered bad behavior to remove versions of a library that others are depending on. Think twice :) If the above doesn't work for you, you can [request a package be unregistered manually](https://github.com/bower/bower/issues/120).
+You'll likely want to [`bower cache clean`](/docs/api#cache-clean) after your change. Please remember it is generally considered bad behavior to remove versions of a library that others are depending on. Think twice :) If the above doesn't work for you, you can [request a package be unregistered manually](https://github.com/bower/registry/issues).


### PR DESCRIPTION
Motivation: Found link to a pull request all the way at the bottom [here](https://bower.io/docs/creating-packages/).

Since https://github.com/bower/bower/issues/2210 is closed, I guess the old documentation of this feature can be restored. I basically rolled back to the previous version of this paragraph.

In addition (and a separate, second commit), I changed the URL to manually request unregistration to the URL mentioned [here](https://github.com/bower/registry#unregister-package). The instructions there are otherwise a copy+paste of the documentation here, as far as I can tell

Just for completeness, #223 is the original removal of the `unregister` feature documentation.