### PR TITLE
Add postuninstall to config docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -79,7 +79,8 @@ Available configuration variables, in `.bowerrc` format:
   "scripts": {
     "preinstall": "",
     "postinstall": "",
-    "preuninstall": ""
+    "preuninstall": "",
+    "postuninstall": ""
   },
   "ignoredDependencies": [
     "jquery"
@@ -111,7 +112,8 @@ In `.bowerrc` do:
   "scripts": {
     "preinstall": "<your command here>",
     "postinstall": "<your command here>",
-    "preuninstall": "<your command here>"
+    "preuninstall": "<your command here>",
+    "postuninstall": "<your command here>"
   }
 }
 {% endhighlight %}


### PR DESCRIPTION
Simply noticed a missing reference to the postuninstall hook added in https://github.com/bower/bower/pull/2252